### PR TITLE
Build maintenance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM nextstrain/nextalign:latest as nextalign
 FROM evolbioinfo/gotree:latest as gotree
-FROM staphb/iqtree2:latest as iqtree2
+FROM staphb/iqtree2:2.1.2 as iqtree2
 FROM nanozoo/seqkit:latest as seqkit
 
 # Using python3.7 image as a parent image
-FROM python:3.7
+FROM --platform=linux/amd64 python:3.7
 # RUN apt-get update && apt-get install -y extra-runtime-dependencies && rm -rf /var/lib/apt/lists/* 
 RUN git clone --depth=1 --branch v0.8.5 https://github.com/neherlab/treetime.git \
 	 && cd treetime \

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 This is a NEXTFLOW implementation for the pipeline for analysing the global source-sink dynamics of VOCs.
 
 ### Setup
-- build the docker image from the provided Dockerfile by running ```docker build -t docker_name .``` in the project folder
-- once you have built the docker image, simply run the provided run.sh bash script file to start experimenting (you might have to make run.sh executable first by running ```chmod +x run.sh```)
-- run.sh will first take the custom config file ex_config.yaml and replace any environmental variables with their corresponding values in your local environment using ```envsubst```; the newly generated config file (ex_sub_config.yaml) is then used as the params-file for running nextflow
+- ensure [`docker`](https://www.docker.com/) is installed and running on your system
+- run the provided `run.sh` bash script file (you might have to make `run.sh` executable first by running ```chmod +x run.sh```)
+
+`run.sh` will first take the custom config file ex_config.yaml and replace any environmental variables with their corresponding values in your local environment using ```envsubst```; the newly generated config file (ex_sub_config.yaml) is then used as the params-file for running nextflow
 
 ### Configuration
 #### Global parameters

--- a/ex_config.yaml
+++ b/ex_config.yaml
@@ -24,7 +24,7 @@ subsampler:
   unit: "week"
 # nextalign params
 nextalign:
-  stop: true
+  stop: false
   reference: "$PWD/resources/nov_sars-cov-2/reference.fasta"
   genemap: "$PWD/resources/nov_sars-cov-2/genemap.gff"
   genes: "E,M,N,ORF1a,ORF1b,ORF3a,ORF6,ORF7a,ORF7b,ORF8,ORF9b,S"

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 envsubst < ex_config.yaml > ex_sub_config.yaml
-nextflow run main.nf -params-file ex_sub_config.yaml -with-docker joetsui1994/vocpl
+docker build -t vocpl .
+nextflow run main.nf -params-file ex_sub_config.yaml -with-docker vocpl


### PR DESCRIPTION
Summary of changes:
- Pin `iqrtree2` docker image version number (as it is later specified in a command path)
- Remove early stop (checkpoint) in pipeline (from `ex_config.yaml`)
- Specify `amd64` for `python3.7` docker image to maintain compatibility with required software packages when building on non-amd64 hardware (e.g. Apple silicon).
- Automatically build and launch a local docker container upon `run.sh` (since pulling `joetsui1994/vocpl` required login/permissions anyway)
- Update build instructions to reflect changes